### PR TITLE
kageco-276 Add Freee integration and enhance credit detail edit features

### DIFF
--- a/apps/web/src/features/household-link-freee/actions/convert-to-deal-data.ts
+++ b/apps/web/src/features/household-link-freee/actions/convert-to-deal-data.ts
@@ -1,0 +1,78 @@
+import type { RegisterDealDto } from "@/core/usecase/freee/register-deal-dto";
+
+/**
+ * レコードを取引データに変換する
+ * @param record 取引レコード
+ * @returns 取引データ
+ */
+export function convertToDealData(record: {
+  id: string;
+  issueDate: string;
+  type: string;
+  companyId: string;
+  dueDate: string;
+  partnerId: string | null;
+  partnerCode: string | null;
+  refNumber: string | null;
+  taxCode: string;
+  accountItemId: string;
+  amount: string;
+  itemId: string | null;
+  sectionId: string | null;
+  tagIds: string[] | null;
+  description: string | null;
+  vat: string | null;
+  fromWalletableId: string;
+  fromWalletableType: string;
+  paymentDate: string;
+}): RegisterDealDto {
+  if (!record) {
+    throw new Error("レコードが提供されていません");
+  }
+
+  // 基本情報
+  const formData = {
+    issueDate: record.issueDate,
+    type: record.type as "income" | "expense",
+    companyId: Number.parseInt(record.companyId, 10),
+    dueDate: record.dueDate,
+    partnerId: record.partnerId ? Number.parseInt(record.partnerId, 10) : null,
+    partnerCode: record.partnerCode,
+    refNumber: record.refNumber,
+  };
+
+  // 明細情報
+  const detail = {
+    taxCode: Number.parseInt(record.taxCode, 10),
+    accountItemId: Number.parseInt(record.accountItemId, 10),
+    amount: Number.parseInt(record.amount, 10),
+    itemId: record.itemId ? Number.parseInt(record.itemId, 10) : null,
+    sectionId: record.sectionId ? Number.parseInt(record.sectionId, 10) : null,
+    tagIds: record.tagIds?.length
+      ? (record.tagIds
+          ?.map((id) => (id ? Number.parseInt(id, 10) : null))
+          .filter(Boolean) as number[])
+      : null,
+    description: record.description,
+    vat: record.vat ? Number.parseInt(record.vat, 10) : null,
+  };
+
+  // 支払情報
+  const payment = {
+    amount: detail.amount,
+    fromWalletableId: Number.parseInt(record.fromWalletableId, 10),
+    fromWalletableType: record.fromWalletableType as "bank_account" | "wallet",
+    date: record.paymentDate,
+  };
+
+  // 領収書ID
+  const receiptId = null;
+
+  // レコードを取引データに変換
+  return {
+    ...formData,
+    details: [detail],
+    payments: [payment],
+    receiptIds: receiptId,
+  };
+}

--- a/apps/web/src/features/household-link-freee/actions/fetch-freee-master-actions.ts
+++ b/apps/web/src/features/household-link-freee/actions/fetch-freee-master-actions.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import { AxiosFreeeAccountItemsRepository } from "@kageco/persistence/api/axios/freee/axios-freee-account-items-repository";
+import { AxiosFreeePartnersRepository } from "@kageco/persistence/api/axios/freee/axios-freee-partners-repository";
+import { AxiosFreeeTaxesRepository } from "@kageco/persistence/api/axios/freee/axios-freee-taxes-repository";
+import { AxiosFreeeWalletablesRepository } from "@kageco/persistence/api/axios/freee/axios-freee-walletables-repository";
+
+import { findFreeeAuth } from "../../../persistence/browser/server/freee-auth";
+
+export const fetchFreeeMasterActions = async () => {
+  const freeeAuth = await findFreeeAuth({ required: false });
+
+  if (!freeeAuth.isSafety) {
+    return {
+      taxes: [],
+      accountItems: [],
+      walletables: [],
+      partners: [],
+    };
+  }
+
+  const accountItemsRepository = new AxiosFreeeAccountItemsRepository(
+    freeeAuth,
+  );
+  const taxRepository = new AxiosFreeeTaxesRepository(freeeAuth);
+  const walletableRepository = new AxiosFreeeWalletablesRepository(freeeAuth);
+  const partnerRepository = new AxiosFreeePartnersRepository(freeeAuth);
+
+  return {
+    taxes: (await taxRepository.getAll()).taxes.map((tax) => ({
+      value: tax.code.toString(),
+      label: tax.name_ja,
+    })),
+    accountItems: grouped(
+      (await accountItemsRepository.getAll()).account_items.map((ai) => ({
+        value: ai.id.toString(),
+        label: ai.name,
+        group: ai.group_name,
+      })),
+    ),
+    walletables: (await walletableRepository.getAll()).walletables.map((w) => ({
+      value: w.id.toString(),
+      label: w.name,
+      type: w.type,
+    })),
+    partners: (await partnerRepository.getAll()).partners
+      .filter((partner) => partner.available)
+      .map((p) => ({
+        value: p.id.toString(),
+        label: p.name,
+      })),
+  };
+};
+
+const grouped = (
+  input: ({ group: string } & Model)[],
+): {
+  group: string;
+  items: Model[];
+}[] => {
+  return Object.values(
+    input.reduce(
+      (acc, { value, label, group }) => {
+        if (!acc[group]) {
+          acc[group] = { group, items: [] };
+        }
+        acc[group].items.push({ value, label });
+        return acc;
+      },
+      {} as Record<string, GroupedModel>,
+    ),
+  );
+};
+
+type Model = {
+  value: string;
+  label: string;
+};
+
+type GroupedModel = {
+  group: string;
+  items: Model[];
+};

--- a/apps/web/src/features/household-link-freee/actions/submit-deal-actions.ts
+++ b/apps/web/src/features/household-link-freee/actions/submit-deal-actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { AxiosFreeeRegisterDealRepository } from "@kageco/persistence/api/axios/freee/axios-freee-register-deal-repository";
+
+import { findFreeeAuth } from "../../../persistence/browser/server/freee-auth";
+import type { UnifiedRecord } from "../types/unified-record";
+import { convertToDealData } from "./convert-to-deal-data";
+
+export const submitDealActions = async (record: UnifiedRecord) => {
+  const freeeAuth = await findFreeeAuth();
+
+  const dealData = convertToDealData(record);
+  const repository = new AxiosFreeeRegisterDealRepository(freeeAuth);
+  await repository.exec({ ...dealData, companyId: freeeAuth.companyId });
+};

--- a/apps/web/src/features/household-link-freee/components/link-freee-detail.module.scss
+++ b/apps/web/src/features/household-link-freee/components/link-freee-detail.module.scss
@@ -1,0 +1,118 @@
+.container {
+  padding: 20px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.heading {
+  font-size: 24px;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 16px;
+}
+
+.cardHeader {
+  background-color: #f5f5f5;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.cardTitle {
+  font-size: 18px;
+  margin: 0;
+  color: #333;
+}
+
+.formContainer {
+  padding: 16px;
+}
+
+.formGroup {
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.formGroup:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.formGroup h3 {
+  font-size: 16px;
+  margin-top: 0;
+  margin-bottom: 16px;
+  color: #333;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.formLabel {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #333;
+  font-size: 14px;
+}
+
+.formField {
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.formField:last-child {
+  margin-bottom: 0;
+}
+
+.formValue {
+  padding: 8px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.required::after {
+  content: " *";
+  color: #ff0000;
+}
+
+.input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #0070f3;
+  box-shadow: 0 0 0 2px rgba(0, 112, 243, 0.2);
+}
+
+.cellContent {
+  padding: 8px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+}

--- a/apps/web/src/features/household-link-freee/components/link-freee-for-credit-card-detail.tsx
+++ b/apps/web/src/features/household-link-freee/components/link-freee-for-credit-card-detail.tsx
@@ -3,10 +3,10 @@ import type { FC, FormEvent } from "react";
 import { ModalTableSelect } from "../../../components/ui";
 import { Button } from "../../../components/ui/button/v5";
 import { LinkFreeeComponent } from "../../freeeAuth/components/link-freee-component";
-import styles from "../../householdModifyDailyDetail/components/link-freee-detail.module.scss";
-import { useStateFreeeMaster } from "../../householdModifyDailyDetail/hooks/use-state-freee-master";
-import { useStateFreeeRecord } from "../hooks/use-state-freee-record";
-import { useStateCreditDetail } from "../hooks/useStateCreditDetail";
+import { useStateCreditDetail } from "../../householdCreditDetailEdit/hooks/useStateCreditDetail";
+import { useStateFreeeMaster } from "../hooks/use-state-freee-master";
+import { useStateFreeeRecord } from "../hooks/use-state-freee-record-credit";
+import styles from "./link-freee-detail.module.scss";
 
 type Props = {
   id: string;

--- a/apps/web/src/features/household-link-freee/components/link-freee-for-daily-detail.tsx
+++ b/apps/web/src/features/household-link-freee/components/link-freee-for-daily-detail.tsx
@@ -1,0 +1,223 @@
+import type { FC, FormEvent } from "react";
+
+import { ModalTableSelect } from "../../../components/ui";
+import { Button } from "../../../components/ui/button/v5";
+import { LinkFreeeComponent } from "../../freeeAuth/components/link-freee-component";
+import { useStateDailyDetail } from "../../householdModifyDailyDetail/hooks/useStateDailyDetail";
+import { useStateFreeeMaster } from "../hooks/use-state-freee-master";
+import { useStateFreeeRecord } from "../hooks/use-state-freee-record-daily";
+import styles from "./link-freee-detail.module.scss";
+
+type Props = {
+  id: string;
+  onClose: () => void;
+};
+
+export const LinkFreeeForDailyDetail: FC<Props> = ({ id, onClose }) => {
+  const { form, loading } = useStateDailyDetail({ id });
+  const { freeeMasters, loadingMasters } = useStateFreeeMaster();
+  const {
+    record,
+    handleRecordChange,
+    handleSubmit: handleSubmitFieldOnly,
+  } = useStateFreeeRecord({
+    form,
+    onClose,
+  });
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    const fromWalletableType = freeeMasters?.walletables.find(
+      (w) => w.value === record?.fromWalletableId,
+    )?.type;
+
+    if (!fromWalletableType) {
+      return;
+    }
+
+    return handleSubmitFieldOnly(fromWalletableType, e);
+  };
+
+  if (loading || loadingMasters) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <LinkFreeeComponent>
+      {record && freeeMasters && (
+        <div className={styles.container}>
+          <form onSubmit={handleSubmit} className={styles.form}>
+            <div className={styles.card}>
+              {/* 基本情報 */}
+              <div className={styles.formField}>
+                <label
+                  htmlFor="issueDate"
+                  className={`${styles.formLabel} ${styles.required}`}
+                >
+                  発生日
+                </label>
+                <input
+                  id="issueDate"
+                  type="date"
+                  value={record.issueDate}
+                  onChange={(e) =>
+                    handleRecordChange("issueDate", e.target.value)
+                  }
+                  className={styles.input}
+                  required
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <span id="typeLabel" className={styles.formLabel}>
+                  収支区分
+                </span>
+                <div className={styles.formValue} aria-labelledby="typeLabel">
+                  {record.type === "income" ? "収入" : "支出"}
+                </div>
+              </div>
+
+              <div className={styles.formField}>
+                <label htmlFor="partnerId" className={styles.formLabel}>
+                  取引先ID
+                </label>
+                <ModalTableSelect
+                  data={freeeMasters.partners}
+                  label={""}
+                  value={record.partnerId}
+                  onChange={(v) => handleRecordChange("partnerId", v)}
+                  maxDropdownHeight={600}
+                  gridColumns={4}
+                />
+              </div>
+
+              {/* 明細情報 */}
+              <div className={styles.formField}>
+                <label htmlFor="taxCode" className={styles.formLabel}>
+                  税区分コード
+                </label>
+                <ModalTableSelect
+                  data={freeeMasters.taxes}
+                  label={""}
+                  value={record.taxCode}
+                  onChange={(v) => handleRecordChange("taxCode", v)}
+                  maxDropdownHeight={600}
+                  gridColumns={4}
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label htmlFor="accountItemId" className={styles.formLabel}>
+                  勘定科目ID
+                </label>
+                <ModalTableSelect
+                  data={freeeMasters.accountItems}
+                  label={""}
+                  value={record.accountItemId}
+                  onChange={(v) => handleRecordChange("accountItemId", v)}
+                  maxDropdownHeight={600}
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label
+                  htmlFor="amount"
+                  className={`${styles.formLabel} ${styles.required}`}
+                >
+                  金額
+                </label>
+                <input
+                  id="amount"
+                  type="number"
+                  value={record.amount}
+                  onChange={(e) => handleRecordChange("amount", e.target.value)}
+                  className={styles.input}
+                  required
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label htmlFor="description" className={styles.formLabel}>
+                  備考
+                </label>
+                <input
+                  id="description"
+                  type="text"
+                  value={record.description}
+                  onChange={(e) =>
+                    handleRecordChange("description", e.target.value)
+                  }
+                  className={styles.input}
+                />
+              </div>
+
+              {/* 支払情報 */}
+              <div className={styles.formField}>
+                <label
+                  htmlFor="paymentAmount"
+                  className={`${styles.formLabel} ${styles.required}`}
+                >
+                  支払金額
+                </label>
+                <input
+                  id="paymentAmount"
+                  type="number"
+                  value={record.paymentAmount}
+                  onChange={(e) =>
+                    handleRecordChange("paymentAmount", e.target.value)
+                  }
+                  className={styles.input}
+                  required
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label
+                  htmlFor="fromWalletableId"
+                  className={`${styles.formLabel} ${styles.required}`}
+                >
+                  口座ID
+                </label>
+                <ModalTableSelect
+                  data={freeeMasters.walletables}
+                  label={""}
+                  value={record.fromWalletableId}
+                  onChange={(v) => handleRecordChange("fromWalletableId", v)}
+                  maxDropdownHeight={400}
+                  gridColumns={1}
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label
+                  htmlFor="paymentDate"
+                  className={`${styles.formLabel} ${styles.required}`}
+                >
+                  支払日
+                </label>
+                <input
+                  id="paymentDate"
+                  type="date"
+                  value={record.paymentDate}
+                  onChange={(e) =>
+                    handleRecordChange("paymentDate", e.target.value)
+                  }
+                  className={styles.input}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className={styles.buttonContainer}>
+              <Button
+                type="save"
+                label={"freeeに登録する"}
+                // @ts-expect-error
+                onClick={handleSubmit}
+              />
+            </div>
+          </form>
+        </div>
+      )}
+    </LinkFreeeComponent>
+  );
+};

--- a/apps/web/src/features/household-link-freee/hooks/use-state-freee-master.ts
+++ b/apps/web/src/features/household-link-freee/hooks/use-state-freee-master.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { fetchFreeeMasterActions } from "../actions/fetch-freee-master-actions";
+
+export type FreeeSelectItem = {
+  value: string;
+  label: string;
+};
+
+export type FreeeAccountItem = {
+  group: string;
+  items: FreeeSelectItem[];
+};
+
+export type FreeeWalletableItem = FreeeSelectItem & {
+  type: string;
+};
+
+export type FreeeMasters = {
+  taxes: FreeeSelectItem[];
+  accountItems: FreeeAccountItem[];
+  walletables: FreeeWalletableItem[];
+  partners: FreeeSelectItem[];
+};
+
+export const useStateFreeeMaster = () => {
+  const [freeeMasters, setFreeeMasters] = useState<FreeeMasters | null>(null);
+  const [loadingMasters, setLoadingMasters] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchMasters = async () => {
+      try {
+        setLoadingMasters(true);
+        const masters = await fetchFreeeMasterActions();
+        setFreeeMasters(masters);
+      } finally {
+        setLoadingMasters(false);
+      }
+    };
+
+    void fetchMasters();
+  }, []);
+
+  return { freeeMasters, loadingMasters };
+};

--- a/apps/web/src/features/household-link-freee/hooks/use-state-freee-record-credit.ts
+++ b/apps/web/src/features/household-link-freee/hooks/use-state-freee-record-credit.ts
@@ -1,0 +1,99 @@
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+
+import { YYYYmmDD } from "@/type/date/date";
+import { errorPopup, successPopup } from "../../../function/successPopup";
+import type {
+  CreditDetailEditDisplayState,
+  CreditDetailEditFormState,
+} from "../../householdCreditDetailEdit/types/type";
+import { submitDealActions } from "../actions/submit-deal-actions";
+import type { UnifiedRecord } from "../types/unified-record";
+
+export const useStateFreeeRecord = (params: {
+  formData: CreditDetailEditFormState | undefined;
+  display: CreditDetailEditDisplayState | undefined;
+  onClose: () => void;
+}) => {
+  const { formData, display, onClose } = params;
+  const [record, setRecord] = useState<UnifiedRecord | null>(null);
+
+  useEffect(() => {
+    if (!formData || !display) return;
+
+    const newRecord: UnifiedRecord = {
+      id: display.id,
+      // 基本情報
+      issueDate: YYYYmmDD.valueOf(display.date).toString(),
+      type: display.iocomeType === "INCOME" ? "income" : "expense",
+      companyId: "",
+      dueDate: "",
+      partnerId: "",
+      partnerCode: "",
+      refNumber: "",
+      // 明細情報
+      taxCode: "",
+      accountItemId: "",
+      amount: display.amount.toString(),
+      itemId: "",
+      sectionId: "",
+      tagIds: [],
+      description: formData.memo || "",
+      vat: "",
+      // 支払情報
+      paymentAmount: display.amount.toString(),
+      fromWalletableId: "",
+      fromWalletableType: "",
+      paymentDate: YYYYmmDD.valueOf(display.withdrawalDate).toString(),
+      // 領収書ID
+      receiptId: "",
+    };
+
+    setRecord(newRecord);
+  }, [formData, display]);
+
+  // レコードの入力ハンドラ
+  const handleRecordChange = (field: keyof UnifiedRecord, value: string) => {
+    if (!record) return;
+
+    const newRecord = { ...record };
+    if (field === "tagIds") {
+      // tagIdsは配列なので特別に処理
+      newRecord[field] = [value];
+    } else {
+      newRecord[field] = value;
+    }
+    setRecord(newRecord);
+  };
+
+  // メッセージ定義
+  const successMessage = "freeeへのデータ送信が完了しました";
+
+  // フォーム送信ハンドラ
+  const handleSubmit = async (
+    fromWalletableType: string,
+    e: FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+
+    if (!record) {
+      errorPopup("レコードが初期化されていません");
+      return;
+    }
+
+    try {
+      await submitDealActions({ ...record, fromWalletableType });
+      successPopup(successMessage);
+      onClose();
+    } catch (error) {
+      console.error("Error submitting data:", error);
+      errorPopup(error as string);
+    }
+  };
+
+  return {
+    record,
+    handleRecordChange,
+    handleSubmit,
+  };
+};

--- a/apps/web/src/features/household-link-freee/hooks/use-state-freee-record-daily.ts
+++ b/apps/web/src/features/household-link-freee/hooks/use-state-freee-record-daily.ts
@@ -1,0 +1,94 @@
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+
+import type { DailyDetail } from "../../../domain/model/household/DailyDetail";
+import { errorPopup, successPopup } from "../../../function/successPopup";
+import { submitDealActions } from "../actions/submit-deal-actions";
+import type { UnifiedRecord } from "../types/unified-record";
+
+export const useStateFreeeRecord = (params: {
+  form: DailyDetail | undefined;
+  onClose: () => void;
+}) => {
+  const { form, onClose } = params;
+  const [record, setRecord] = useState<UnifiedRecord | null>(null);
+
+  useEffect(() => {
+    if (!form) return;
+
+    const newRecord: UnifiedRecord = {
+      id: form.id,
+      // 基本情報
+      issueDate: form.date,
+      type: form.iocomeType === "INCOME" ? "income" : "expense",
+      companyId: "",
+      dueDate: "",
+      partnerId: "",
+      partnerCode: "",
+      refNumber: "",
+      // 明細情報
+      taxCode: "",
+      accountItemId: "",
+      amount: form.amount.toString(),
+      itemId: "",
+      sectionId: "",
+      tagIds: [],
+      description: `${form.categoryName}-${form.memo}`,
+      vat: "",
+      // 支払情報
+      paymentAmount: form.amount.toString(),
+      fromWalletableId: "",
+      fromWalletableType: "",
+      paymentDate: form.date,
+      // 領収書ID
+      receiptId: "",
+    };
+
+    setRecord(newRecord);
+  }, [form]);
+
+  // レコードの入力ハンドラ
+  const handleRecordChange = (field: keyof UnifiedRecord, value: string) => {
+    if (!record) return;
+
+    const newRecord = { ...record };
+    if (field === "tagIds") {
+      // tagIdsは配列なので特別に処理
+      newRecord[field] = [value];
+    } else {
+      newRecord[field] = value;
+    }
+    setRecord(newRecord);
+  };
+
+  // メッセージ定義
+  const successMessage = "freeeへのデータ送信が完了しました";
+
+  // フォーム送信ハンドラ
+  const handleSubmit = async (
+    fromWalletableType: string,
+    e: FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+
+    if (!record) {
+      errorPopup("レコードが初期化されていません");
+      return;
+    }
+
+    try {
+      await submitDealActions({ ...record, fromWalletableType });
+      successPopup(successMessage);
+      onClose();
+    } catch (error) {
+      console.error("Error submitting data:", error);
+      errorPopup(error as string);
+    }
+  };
+
+  return {
+    record,
+    handleRecordChange,
+    handleSubmit,
+  };
+};

--- a/apps/web/src/features/household-link-freee/types/unified-record.ts
+++ b/apps/web/src/features/household-link-freee/types/unified-record.ts
@@ -1,0 +1,30 @@
+/**
+ * freeeへ取引登録するためのレコード型定義
+ */
+export type UnifiedRecord = {
+  id: string;
+  // 基本情報
+  issueDate: string;
+  type: string;
+  companyId: string;
+  dueDate: string;
+  partnerId: string;
+  partnerCode: string;
+  refNumber: string;
+  // 明細情報
+  taxCode: string;
+  accountItemId: string;
+  amount: string;
+  itemId: string;
+  sectionId: string;
+  tagIds: string[];
+  description: string;
+  vat: string;
+  // 支払情報
+  paymentAmount: string;
+  fromWalletableId: string;
+  fromWalletableType: string;
+  paymentDate: string;
+  // 領収書ID
+  receiptId: string;
+};

--- a/apps/web/src/features/householdAccountList/components/AccountDetailTable.tsx
+++ b/apps/web/src/features/householdAccountList/components/AccountDetailTable.tsx
@@ -8,7 +8,7 @@ import { TagGroup } from "../../../components/ui/tag/TagGroup";
 import { DataTable } from "../../../components/ui/v4/table";
 import type { IocomeType } from "../../../domain/model/household/IocomeType";
 import { convertToYmd } from "../../../function/date/convertToYmd";
-import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/DailyDetailEditModal";
+import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/daily-detail-edit-modal";
 import type { AccountDetailRow } from "../types/accountDetailRow";
 
 export const AccountDetailTable = ({

--- a/apps/web/src/features/householdChartDetailTable/components/ChartDetailTableClient.tsx
+++ b/apps/web/src/features/householdChartDetailTable/components/ChartDetailTableClient.tsx
@@ -8,7 +8,7 @@ import { DataTable } from "../../../components/ui/v4/table";
 import { IocomeType } from "../../../domain/model/household/IocomeType";
 import { colors } from "../../../styles/colors";
 import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/credit-card-detail-edit-model";
-import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/DailyDetailEditModal";
+import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/daily-detail-edit-modal";
 import type { ChartDetailTableRow } from "../types/chartDetailTableRow";
 
 export const ChartDetailTableClient = ({

--- a/apps/web/src/features/householdChartDetailTable/components/ChartDetailTableClient.tsx
+++ b/apps/web/src/features/householdChartDetailTable/components/ChartDetailTableClient.tsx
@@ -7,7 +7,7 @@ import { Tag } from "../../../components/ui/tag/Tag";
 import { DataTable } from "../../../components/ui/v4/table";
 import { IocomeType } from "../../../domain/model/household/IocomeType";
 import { colors } from "../../../styles/colors";
-import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/CreditCardDetailEditModel";
+import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/credit-card-detail-edit-model";
 import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/DailyDetailEditModal";
 import type { ChartDetailTableRow } from "../types/chartDetailTableRow";
 

--- a/apps/web/src/features/householdCreditDetailEdit/components/CreditCardDetailEditModel.tsx
+++ b/apps/web/src/features/householdCreditDetailEdit/components/CreditCardDetailEditModel.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps, FC } from "react";
 
 import { Modal } from "../../../components/atoms/Modal";
+import { Tab } from "../../../components/ui";
 import { CreditCardDetailEditContainer } from "./CreditCardDetailEditContainer";
 
 type Props = ComponentProps<typeof CreditCardDetailEditContainer> & {
@@ -15,7 +16,19 @@ export const CreditCardDetailEditModal: FC<Props> = ({
 }) => {
   return (
     <Modal opened={isOpen} onClose={onCloseHandler}>
-      <CreditCardDetailEditContainer id={id} onClose={onCloseHandler} />
+      <Tab
+        defaultSelect={"creditCard"}
+        tabPropsList={[
+          {
+            value: "creditCard",
+            label: "変更",
+            icon: null,
+            contents: (
+              <CreditCardDetailEditContainer id={id} onClose={onCloseHandler} />
+            ),
+          },
+        ]}
+      />
     </Modal>
   );
 };

--- a/apps/web/src/features/householdCreditDetailEdit/components/credit-card-detail-edit-model.tsx
+++ b/apps/web/src/features/householdCreditDetailEdit/components/credit-card-detail-edit-model.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, FC } from "react";
 import { Modal } from "../../../components/atoms/Modal";
 import { Tab } from "../../../components/ui";
 import { CreditCardDetailEditContainer } from "./CreditCardDetailEditContainer";
+import { LinkFreeeForCreditCardDetail } from "./link-freee-for-credit-card-detail";
 
 type Props = ComponentProps<typeof CreditCardDetailEditContainer> & {
   isOpen: boolean;
@@ -25,6 +26,14 @@ export const CreditCardDetailEditModal: FC<Props> = ({
             icon: null,
             contents: (
               <CreditCardDetailEditContainer id={id} onClose={onCloseHandler} />
+            ),
+          },
+          {
+            value: "freee",
+            label: "freee連携",
+            icon: null,
+            contents: (
+              <LinkFreeeForCreditCardDetail id={id} onClose={onCloseHandler} />
             ),
           },
         ]}

--- a/apps/web/src/features/householdCreditDetailEdit/components/credit-card-detail-edit-model.tsx
+++ b/apps/web/src/features/householdCreditDetailEdit/components/credit-card-detail-edit-model.tsx
@@ -2,8 +2,8 @@ import type { ComponentProps, FC } from "react";
 
 import { Modal } from "../../../components/atoms/Modal";
 import { Tab } from "../../../components/ui";
+import { LinkFreeeForCreditCardDetail } from "../../household-link-freee/components/link-freee-for-credit-card-detail";
 import { CreditCardDetailEditContainer } from "./CreditCardDetailEditContainer";
-import { LinkFreeeForCreditCardDetail } from "./link-freee-for-credit-card-detail";
 
 type Props = ComponentProps<typeof CreditCardDetailEditContainer> & {
   isOpen: boolean;

--- a/apps/web/src/features/householdCreditDetailEdit/components/link-freee-for-credit-card-detail.tsx
+++ b/apps/web/src/features/householdCreditDetailEdit/components/link-freee-for-credit-card-detail.tsx
@@ -3,25 +3,26 @@ import type { FC, FormEvent } from "react";
 import { ModalTableSelect } from "../../../components/ui";
 import { Button } from "../../../components/ui/button/v5";
 import { LinkFreeeComponent } from "../../freeeAuth/components/link-freee-component";
-import { useStateFreeeMaster } from "../hooks/use-state-freee-master";
+import styles from "../../householdModifyDailyDetail/components/link-freee-detail.module.scss";
+import { useStateFreeeMaster } from "../../householdModifyDailyDetail/hooks/use-state-freee-master";
 import { useStateFreeeRecord } from "../hooks/use-state-freee-record";
-import { useStateDailyDetail } from "../hooks/useStateDailyDetail";
-import styles from "./link-freee-detail.module.scss";
+import { useStateCreditDetail } from "../hooks/useStateCreditDetail";
 
 type Props = {
   id: string;
   onClose: () => void;
 };
 
-export const LinkFreeeForDailyDetail: FC<Props> = ({ id, onClose }) => {
-  const { form, loading } = useStateDailyDetail({ id });
+export const LinkFreeeForCreditCardDetail: FC<Props> = ({ id, onClose }) => {
+  const { formData, display, loading } = useStateCreditDetail({ id });
   const { freeeMasters, loadingMasters } = useStateFreeeMaster();
   const {
     record,
     handleRecordChange,
     handleSubmit: handleSubmitFieldOnly,
   } = useStateFreeeRecord({
-    form,
+    formData,
+    display,
     onClose,
   });
 

--- a/apps/web/src/features/householdCreditDetailEdit/hooks/use-state-freee-record.ts
+++ b/apps/web/src/features/householdCreditDetailEdit/hooks/use-state-freee-record.ts
@@ -1,26 +1,31 @@
 import type { FormEvent } from "react";
 import { useEffect, useState } from "react";
 
-import type { DailyDetail } from "../../../domain/model/household/DailyDetail";
+import { YYYYmmDD } from "@/type/date/date";
 import { errorPopup, successPopup } from "../../../function/successPopup";
-import { submitDealActions } from "../actions/submit-deal-actions";
-import type { UnifiedRecord } from "../types/unified-record";
+import { submitDealActions } from "../../householdModifyDailyDetail/actions/submit-deal-actions";
+import type { UnifiedRecord } from "../../householdModifyDailyDetail/types/unified-record";
+import type {
+  CreditDetailEditDisplayState,
+  CreditDetailEditFormState,
+} from "../types/type";
 
 export const useStateFreeeRecord = (params: {
-  form: DailyDetail | undefined;
+  formData: CreditDetailEditFormState | undefined;
+  display: CreditDetailEditDisplayState | undefined;
   onClose: () => void;
 }) => {
-  const { form, onClose } = params;
+  const { formData, display, onClose } = params;
   const [record, setRecord] = useState<UnifiedRecord | null>(null);
 
   useEffect(() => {
-    if (!form) return;
+    if (!formData || !display) return;
 
     const newRecord: UnifiedRecord = {
-      id: form.id,
+      id: display.id,
       // 基本情報
-      issueDate: form.date,
-      type: form.iocomeType === "INCOME" ? "income" : "expense",
+      issueDate: YYYYmmDD.valueOf(display.date).toString(),
+      type: display.iocomeType === "INCOME" ? "income" : "expense",
       companyId: "",
       dueDate: "",
       partnerId: "",
@@ -29,23 +34,23 @@ export const useStateFreeeRecord = (params: {
       // 明細情報
       taxCode: "",
       accountItemId: "",
-      amount: form.amount.toString(),
+      amount: display.amount.toString(),
       itemId: "",
       sectionId: "",
       tagIds: [],
-      description: `${form.categoryName}-${form.memo}`,
+      description: formData.memo || "",
       vat: "",
       // 支払情報
-      paymentAmount: form.amount.toString(),
+      paymentAmount: display.amount.toString(),
       fromWalletableId: "",
       fromWalletableType: "",
-      paymentDate: form.date,
+      paymentDate: YYYYmmDD.valueOf(display.withdrawalDate).toString(),
       // 領収書ID
       receiptId: "",
     };
 
     setRecord(newRecord);
-  }, [form]);
+  }, [formData, display]);
 
   // レコードの入力ハンドラ
   const handleRecordChange = (field: keyof UnifiedRecord, value: string) => {

--- a/apps/web/src/features/householdCreditDetailEdit/hooks/useStateCreditDetail.ts
+++ b/apps/web/src/features/householdCreditDetailEdit/hooks/useStateCreditDetail.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { YYYYmmDD } from "@/type/date/date";
 import { IocomeType } from "../../../domain/model/household/IocomeType";
 import type {
   CreditDetailEditDisplayState,
@@ -18,6 +19,7 @@ export const useStateCreditDetail = ({ id }: { id: string }) => {
     date: new Date(),
     iocomeType: IocomeType.Income,
     amount: 0,
+    withdrawalDate: new Date(),
   });
   const [initData, setInitData] = useState<{
     genreId: string;
@@ -46,9 +48,10 @@ export const useStateCreditDetail = ({ id }: { id: string }) => {
       });
       setDisplay({
         id,
-        date: initData.date,
+        date: new Date(initData.date),
         iocomeType: initData.iocomeType,
         amount: initData.amount,
+        withdrawalDate: new Date(initData.withdrawalDate),
       });
     })();
 

--- a/apps/web/src/features/householdCreditDetailEdit/types/type.ts
+++ b/apps/web/src/features/householdCreditDetailEdit/types/type.ts
@@ -11,4 +11,5 @@ export type CreditDetailEditDisplayState = {
   date: Date;
   iocomeType: IocomeType;
   amount: number;
+  withdrawalDate: Date;
 };

--- a/apps/web/src/features/householdCreditDetailEdit/useServer/fetchCreditCardDetailById.ts
+++ b/apps/web/src/features/householdCreditDetailEdit/useServer/fetchCreditCardDetailById.ts
@@ -2,6 +2,7 @@
 
 import { GetCreditCardDetailByIdDocument } from "@v3/graphql/household/schema/query/v5/getCreditCardDetailById.generated";
 
+import type { YYYY_MM_DD } from "@/type/date/date";
 import { IocomeType } from "../../../domain/model/household/IocomeType";
 import { execQuery } from "../../../persistence/database/server/execQuery";
 
@@ -11,7 +12,8 @@ export const fetchCreditCardDetailById = async (id: string) => {
   });
 
   const initData = {
-    date: new Date(data?.creditCardDetail?.date as string),
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    date: data?.creditCardDetail?.date!,
     iocomeType:
       (data?.creditCardDetail?.genre?.iocomeType as IocomeType) ??
       IocomeType.Income,
@@ -20,6 +22,17 @@ export const fetchCreditCardDetailById = async (id: string) => {
     amount: Number(data?.creditCardDetail?.amount) ?? "",
     memo: data?.creditCardDetail?.memo ?? "",
     tags: data?.creditCardDetail?.tags.map((tag) => tag.tag.id) ?? [],
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    withdrawalDate: data?.creditCardDetail?.summary.withdrawalDate!,
+  } satisfies {
+    date: YYYY_MM_DD;
+    iocomeType: IocomeType;
+    genreId: string;
+    categoryId: string;
+    amount: number;
+    memo: string;
+    tags: string[];
+    withdrawalDate: YYYY_MM_DD;
   };
 
   return {

--- a/apps/web/src/features/householdModifyDailyDetail/components/DailyDetailEditModal.tsx
+++ b/apps/web/src/features/householdModifyDailyDetail/components/DailyDetailEditModal.tsx
@@ -3,7 +3,7 @@ import { Tab } from "../../../components/ui";
 import { CutDailyDetail } from "./CutDailyDetail";
 import { DuplicateDailyDetail } from "./DuplicateDailyDetail";
 import { ModifyDailyDetail } from "./ModifyDailyDetail";
-import { LinkFreeeDetail } from "./link-freee-detail";
+import { LinkFreeeForDailyDetail } from "./link-freee-for-daily-detail";
 
 export const DailyDetailEditModal = ({
   id,
@@ -40,7 +40,9 @@ export const DailyDetailEditModal = ({
           value: "freee",
           label: "freee連携",
           icon: null,
-          contents: <LinkFreeeDetail id={id} onClose={onCloseHandler} />,
+          contents: (
+            <LinkFreeeForDailyDetail id={id} onClose={onCloseHandler} />
+          ),
         },
       ]}
     />

--- a/apps/web/src/features/householdModifyDailyDetail/components/daily-detail-edit-modal.tsx
+++ b/apps/web/src/features/householdModifyDailyDetail/components/daily-detail-edit-modal.tsx
@@ -1,9 +1,9 @@
 import { Modal } from "../../../components/atoms/Modal";
 import { Tab } from "../../../components/ui";
+import { LinkFreeeForDailyDetail } from "../../household-link-freee/components/link-freee-for-daily-detail";
 import { CutDailyDetail } from "./CutDailyDetail";
 import { DuplicateDailyDetail } from "./DuplicateDailyDetail";
 import { ModifyDailyDetail } from "./ModifyDailyDetail";
-import { LinkFreeeForDailyDetail } from "./link-freee-for-daily-detail";
 
 export const DailyDetailEditModal = ({
   id,

--- a/apps/web/src/features/householdModifyDailyDetail/components/link-freee-for-daily-detail.tsx
+++ b/apps/web/src/features/householdModifyDailyDetail/components/link-freee-for-daily-detail.tsx
@@ -13,7 +13,7 @@ type Props = {
   onClose: () => void;
 };
 
-export const LinkFreeeDetail: FC<Props> = ({ id, onClose }) => {
+export const LinkFreeeForDailyDetail: FC<Props> = ({ id, onClose }) => {
   const { form, loading } = useStateDailyDetail({ id });
   const { freeeMasters, loadingMasters } = useStateFreeeMaster();
   const {

--- a/apps/web/src/features/householdSearch/components/search-list-table.tsx
+++ b/apps/web/src/features/householdSearch/components/search-list-table.tsx
@@ -6,7 +6,7 @@ import { FormatPrice } from "../../../components/molecules/FormatPrice";
 import { TagGroup } from "../../../components/ui/tag/TagGroup";
 import { DataTable } from "../../../components/ui/v4/table";
 import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/credit-card-detail-edit-model";
-import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/DailyDetailEditModal";
+import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/daily-detail-edit-modal";
 import type { SearchRow } from "../types/searchRow";
 
 type Props = {

--- a/apps/web/src/features/householdSearch/components/search-list-table.tsx
+++ b/apps/web/src/features/householdSearch/components/search-list-table.tsx
@@ -5,7 +5,7 @@ import { type FC, useState } from "react";
 import { FormatPrice } from "../../../components/molecules/FormatPrice";
 import { TagGroup } from "../../../components/ui/tag/TagGroup";
 import { DataTable } from "../../../components/ui/v4/table";
-import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/CreditCardDetailEditModel";
+import { CreditCardDetailEditModal } from "../../householdCreditDetailEdit/components/credit-card-detail-edit-model";
 import { DailyDetailEditModal } from "../../householdModifyDailyDetail/components/DailyDetailEditModal";
 import type { SearchRow } from "../types/searchRow";
 

--- a/packages/graphql/household/schema/batch-sort-category/getAllCategories.generated.ts
+++ b/packages/graphql/household/schema/batch-sort-category/getAllCategories.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/batch-sort-category/getRecentDetails.generated.ts
+++ b/packages/graphql/household/schema/batch-sort-category/getRecentDetails.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/batch-sort-category/updateCategoryDisplayOrder.generated.ts
+++ b/packages/graphql/household/schema/batch-sort-category/updateCategoryDisplayOrder.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/master/queryDetailMaster.generated.ts
+++ b/packages/graphql/household/schema/master/queryDetailMaster.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateCategory.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateCategory.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateCreditCardDetail.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateCreditCardDetail.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateCreditCardSummary.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateCreditCardSummary.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateDailyDetail.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateDailyDetail.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateImportFileHistory.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateImportFileHistory.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/create/CreateUser.generated.ts
+++ b/packages/graphql/household/schema/mutation/create/CreateUser.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/delete/DeleteDailyDetailBySerialNo.generated.ts
+++ b/packages/graphql/household/schema/mutation/delete/DeleteDailyDetailBySerialNo.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/update/UpdateCategoryById.generated.ts
+++ b/packages/graphql/household/schema/mutation/update/UpdateCategoryById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/update/UpdateDailyDetailById.generated.ts
+++ b/packages/graphql/household/schema/mutation/update/UpdateDailyDetailById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/update/UpdateGenreById.generated.ts
+++ b/packages/graphql/household/schema/mutation/update/UpdateGenreById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/deleteDashboardSetting.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/deleteDashboardSetting.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/deleteFavoriteFilterArg.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/deleteFavoriteFilterArg.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/deleteInsertDashboardSettingArgs.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/deleteInsertDashboardSettingArgs.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/insertDashboardSetting.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/insertDashboardSetting.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/insertFavoriteFilter.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/insertFavoriteFilter.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/insertFavoriteFilterArg.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/insertFavoriteFilterArg.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/updateCreditCardDetailAmountById.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/updateCreditCardDetailAmountById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/updateDashboardSetting.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/updateDashboardSetting.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/updateDashboardSettingOrder.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/updateDashboardSettingOrder.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/updateFavoriteFilter.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/updateFavoriteFilter.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v3/updateFavoriteFilterArg.generated.ts
+++ b/packages/graphql/household/schema/mutation/v3/updateFavoriteFilterArg.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v5/mutateConditionSession.generated.ts
+++ b/packages/graphql/household/schema/mutation/v5/mutateConditionSession.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v5/mutateTag.generated.ts
+++ b/packages/graphql/household/schema/mutation/v5/mutateTag.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v5/updateCreditCardDetailById.generated.ts
+++ b/packages/graphql/household/schema/mutation/v5/updateCreditCardDetailById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/mutation/v5/updateCreditSummary.generated.ts
+++ b/packages/graphql/household/schema/mutation/v5/updateCreditSummary.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetAllCategories.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetAllCategories.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetAllCategoryListWithCriteria.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetAllCategoryListWithCriteria.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetAllGenre.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetAllGenre.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetAllUsers.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetAllUsers.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetCategoryById.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetCategoryById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetCreditCardList.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetCreditCardList.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/GetDailyDetailByDate.generated.ts
+++ b/packages/graphql/household/schema/query/get/GetDailyDetailByDate.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/get/getCreditCardSummaryByDate.generated.ts
+++ b/packages/graphql/household/schema/query/get/getCreditCardSummaryByDate.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/fragFavoriteFilter.generated.ts
+++ b/packages/graphql/household/schema/query/v3/fragFavoriteFilter.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getAccountById.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getAccountById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getCreditCardDetailList.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getCreditCardDetailList.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */
@@ -4410,6 +4466,7 @@ export type GetCreditCardDetailListQuery = {
     summary: {
       __typename?: "HouseholdCreditCardSummary";
       id: string;
+      withdrawalDate: YYYY_MM_DD;
       account: { __typename?: "HouseholdAccount"; id: string; name: string };
     };
     tags: Array<{
@@ -4617,6 +4674,10 @@ export const GetCreditCardDetailListDocument = {
               kind: "SelectionSet",
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "withdrawalDate" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "account" },

--- a/packages/graphql/household/schema/query/v3/getCreditCardSummaryByAccountId.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getCreditCardSummaryByAccountId.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getCreditCardSummaryById.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getCreditCardSummaryById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getDailyByAccountId.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getDailyByAccountId.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getFavoriteFilter.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getFavoriteFilter.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v3/getFavoriteFilters.generated.ts
+++ b/packages/graphql/household/schema/query/v3/getFavoriteFilters.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/chartData.generated.ts
+++ b/packages/graphql/household/schema/query/v5/chartData.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/chartDetailTable.generated.ts
+++ b/packages/graphql/household/schema/query/v5/chartDetailTable.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/fragChartDetailTable.generated.ts
+++ b/packages/graphql/household/schema/query/v5/fragChartDetailTable.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/fragCreditCardDetail.generated.ts
+++ b/packages/graphql/household/schema/query/v5/fragCreditCardDetail.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */
@@ -4402,6 +4458,7 @@ export type FragCreditCardDetailFragment = {
   summary: {
     __typename?: "HouseholdCreditCardSummary";
     id: string;
+    withdrawalDate: YYYY_MM_DD;
     account: { __typename?: "HouseholdAccount"; id: string; name: string };
   };
   tags: Array<{
@@ -4466,6 +4523,10 @@ export const FragCreditCardDetailFragmentDoc = {
               kind: "SelectionSet",
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "withdrawalDate" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "account" },

--- a/packages/graphql/household/schema/query/v5/fragCreditCardDetail.graphql
+++ b/packages/graphql/household/schema/query/v5/fragCreditCardDetail.graphql
@@ -15,6 +15,7 @@ fragment fragCreditCardDetail on HouseholdCreditCardDetail {
   }
   summary: creditCardSummary {
     id
+    withdrawalDate
     account {
       id
       name

--- a/packages/graphql/household/schema/query/v5/fragDailyDetail.generated.ts
+++ b/packages/graphql/household/schema/query/v5/fragDailyDetail.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/fragTag.generated.ts
+++ b/packages/graphql/household/schema/query/v5/fragTag.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/fragTransferCategory.generated.ts
+++ b/packages/graphql/household/schema/query/v5/fragTransferCategory.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getAccountBalanceList.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getAccountBalanceList.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getAllDetailView.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getAllDetailView.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getCategorizedDetails.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getCategorizedDetails.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getCreditCardDetailById.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getCreditCardDetailById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */
@@ -4408,6 +4464,7 @@ export type GetCreditCardDetailByIdQuery = {
     summary: {
       __typename?: "HouseholdCreditCardSummary";
       id: string;
+      withdrawalDate: YYYY_MM_DD;
       account: { __typename?: "HouseholdAccount"; id: string; name: string };
     };
     tags: Array<{
@@ -4538,6 +4595,10 @@ export const GetCreditCardDetailByIdDocument = {
               kind: "SelectionSet",
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "withdrawalDate" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "account" },

--- a/packages/graphql/household/schema/query/v5/getCreditCardDetailBySummaryId.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getCreditCardDetailBySummaryId.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */
@@ -4416,6 +4472,7 @@ export type GetCreditCardDetailBySummaryIdQuery = {
       summary: {
         __typename?: "HouseholdCreditCardSummary";
         id: string;
+        withdrawalDate: YYYY_MM_DD;
         account: { __typename?: "HouseholdAccount"; id: string; name: string };
       };
       tags: Array<{
@@ -4591,6 +4648,10 @@ export const GetCreditCardDetailBySummaryIdDocument = {
               kind: "SelectionSet",
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "withdrawalDate" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "account" },

--- a/packages/graphql/household/schema/query/v5/getDailyDetailById.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getDailyDetailById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getDashboardBalance.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getDashboardBalance.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getDashboardSetting.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getDashboardSetting.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getDetailsByAccountId.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getDetailsByAccountId.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getDetailsByCategory.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getDetailsByCategory.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */
@@ -4449,6 +4505,7 @@ export type GetDetailsByCategoryQuery = {
       summary: {
         __typename?: "HouseholdCreditCardSummary";
         id: string;
+        withdrawalDate: YYYY_MM_DD;
         account: { __typename?: "HouseholdAccount"; id: string; name: string };
       };
       tags: Array<{
@@ -4480,6 +4537,7 @@ export type GetDetailsByCategoryQuery = {
       summary: {
         __typename?: "HouseholdCreditCardSummary";
         id: string;
+        withdrawalDate: YYYY_MM_DD;
         account: { __typename?: "HouseholdAccount"; id: string; name: string };
       };
       tags: Array<{
@@ -5036,6 +5094,10 @@ export const GetDetailsByCategoryDocument = {
               kind: "SelectionSet",
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "withdrawalDate" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "account" },

--- a/packages/graphql/household/schema/query/v5/getGenreById.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getGenreById.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getTransferCategory.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getTransferCategory.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getValidAccounts.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getValidAccounts.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getValidCategoryByGenreId.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getValidCategoryByGenreId.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/getValidGenreListByIocomeType.generated.ts
+++ b/packages/graphql/household/schema/query/v5/getValidGenreListByIocomeType.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/queryConditionSession.generated.ts
+++ b/packages/graphql/household/schema/query/v5/queryConditionSession.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/query/v5/queryTag.generated.ts
+++ b/packages/graphql/household/schema/query/v5/queryTag.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/template/get-template.generated.ts
+++ b/packages/graphql/household/schema/template/get-template.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */

--- a/packages/graphql/household/schema/template/insert-template.generated.ts
+++ b/packages/graphql/household/schema/template/insert-template.generated.ts
@@ -621,6 +621,62 @@ export type BusinessDailyAttendanceVarianceOrderBy = {
   breakSecond: InputMaybe<OrderBy>;
 };
 
+/** Boolean expression to filter rows from the table "business.monthly_plan". All fields are combined with a logical 'AND'. */
+export type BusinessMonthlyPlanBoolExp = {
+  _and: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  _not: InputMaybe<BusinessMonthlyPlanBoolExp>;
+  _or: InputMaybe<Array<BusinessMonthlyPlanBoolExp>>;
+  businessDays: InputMaybe<IntComparisonExp>;
+  id: InputMaybe<StringComparisonExp>;
+  plannedWorkingHoursLower: InputMaybe<NumericComparisonExp>;
+  plannedWorkingHoursUpper: InputMaybe<NumericComparisonExp>;
+  userId: InputMaybe<StringComparisonExp>;
+  yearMonth: InputMaybe<BpcharComparisonExp>;
+};
+
+/** Ordering options when selecting data from "business.monthly_plan". */
+export type BusinessMonthlyPlanOrderBy = {
+  businessDays: InputMaybe<OrderBy>;
+  id: InputMaybe<OrderBy>;
+  plannedWorkingHoursLower: InputMaybe<OrderBy>;
+  plannedWorkingHoursUpper: InputMaybe<OrderBy>;
+  userId: InputMaybe<OrderBy>;
+  yearMonth: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "business.monthly_plan" */
+export type BusinessMonthlyPlanSelectColumn =
+  /** column name */
+  | "businessDays"
+  /** column name */
+  | "id"
+  /** column name */
+  | "plannedWorkingHoursLower"
+  /** column name */
+  | "plannedWorkingHoursUpper"
+  /** column name */
+  | "userId"
+  /** column name */
+  | "yearMonth";
+
+/** Streaming cursor of the table "business_monthly_plan" */
+export type BusinessMonthlyPlanStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: BusinessMonthlyPlanStreamCursorValueInput;
+  /** cursor ordering */
+  ordering: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type BusinessMonthlyPlanStreamCursorValueInput = {
+  businessDays: InputMaybe<Scalars["Int"]>;
+  id: InputMaybe<Scalars["String"]>;
+  plannedWorkingHoursLower: InputMaybe<Scalars["numeric"]>;
+  plannedWorkingHoursUpper: InputMaybe<Scalars["numeric"]>;
+  userId: InputMaybe<Scalars["String"]>;
+  yearMonth: InputMaybe<Scalars["bpchar"]>;
+};
+
 /** ordering argument of a cursor */
 export type CursorOrdering =
   /** ascending ordering of the cursor */


### PR DESCRIPTION
- Implemented Freee integration: added master data retrieval and transaction submission logic.
- Refactored existing components for structural consistency.
- Enhanced credit card detail editing:
  - Added a `withdrawalDate` field.
  - Created a new `LinkFreeeForCreditCardDetail` component and integrated it as a tab.
  - Removed unnecessary memo input fields.
  - Adjusted UI by introducing a tab component in the modal.
- Renamed `LinkFreeeDetail` to `LinkFreeeForDailyDetail`.
- Performed clean-up tasks: updated type definitions, fixed path names, and removed unused code/comments.